### PR TITLE
Fix issue #976

### DIFF
--- a/custom_components/better_thermostat/utils/controlling.py
+++ b/custom_components/better_thermostat/utils/controlling.py
@@ -109,6 +109,18 @@ async def control_trv(self, heater_entity_id=None):
         if self.call_for_heat is False:
             _new_hvac_mode = HVACMode.OFF
 
+        # Manage TRVs with no HVACMode.OFF
+        _no_off_system_mode = (
+            HVACMode.OFF not in self.real_trvs[heater_entity_id]["hvac_modes"]
+            or self.real_trvs[heater_entity_id]["advanced"].get("no_off_system_mode", False)
+        )
+        if _no_off_system_mode is True and _new_hvac_mode == HVACMode.OFF:
+            _min_temp = self.real_trvs[heater_entity_id]["min_temp"]
+            _LOGGER.debug(
+                f"better_thermostat {self.name}: sending {_min_temp}°C to the TRV because this device has no system mode off and heater should be off"
+            )
+            _temperature = _min_temp
+
         # send new HVAC mode to TRV, if it changed
         if _new_hvac_mode is not None and _new_hvac_mode != _trv.state:
             _LOGGER.debug(
@@ -162,7 +174,11 @@ async def control_trv(self, heater_entity_id=None):
                 self.real_trvs[heater_entity_id]["calibration_received"] = False
 
         # set new target temperature
-        if _temperature is not None and _new_hvac_mode != HVACMode.OFF:
+        if (
+            _temperature is not None
+            and _new_hvac_mode != HVACMode.OFF
+            or _no_off_system_mode
+        ):
             if _temperature != _current_set_temperature:
                 old = self.real_trvs[heater_entity_id].get("last_temperature", "?")
                 _LOGGER.debug(


### PR DESCRIPTION
## Motivation:

Fixing an opened issue

## Changes:

Detect devices with no HVACMode.OFF and set temperature acordingly

## Related issue (check one):

- [X] fixes #976
- [ ] there is no related issue ticket

## Checklist (check one):

- [ ] I did not change any code (e.g. documentation changes)
- [X] The code change is tested and works locally.

## Test-Hardware list (for code changes)

<!-- Please specify your hardware/software which was used to test the code locally: -->

HA Version: 2023.3.6
Zigbee2MQTT Version: 1.30.2
TRV Hardware: Moes BRT-100-TRV

## New device mappings

<!-- If there was a new device mapping added, please make sure to fill in this checklist: -->

- [X] I avoided any changes to other device mappings
- [X] There are no changes in `climate.py`

<!-- If you did change the `climate.py` please create a dedicated PR for this. -->
